### PR TITLE
fix: api missing resource

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -106,6 +106,7 @@ const apiGWGenerator = () => {
     Effect: 'Allow',
     Action: ['apigateway:GET', 'apigateway:POST', 'apigateway:PUT', 'apigateway:DELETE', 'apigateway:PATCH'],
     Resource: [
+      "arn:aws:apigateway:*::/apis*",
       'arn:aws:apigateway:*::/restapis*',
       'arn:aws:apigateway:*::/apikeys*',
       'arn:aws:apigateway:*::/usageplans*',


### PR DESCRIPTION
Added missing resource type in the policy document