### PR TITLE
added support for serverless domain manager

### DIFF
--- a/docs/DOMAIN_MANAGER.md
+++ b/docs/DOMAIN_MANAGER.md
@@ -1,0 +1,26 @@
+# Serverless Domain Manager
+
+The [serverless domain manager](https://www.npmjs.com/package/serverless-domain-manager) is a plugin for the serverless.com system.
+
+The IAM roles required for deploying when using the serverless-domain manager:
+
+```
+acm:ListCertificates                *
+apigateway:GET                      /domainnames/*
+apigateway:GET                      /domainnames/*/basepathmappings
+apigateway:DELETE                   /domainnames/*
+apigateway:POST                     /domainnames
+apigateway:POST                     /domainnames/*/basepathmappings
+apigateway:PATCH                    /domainnames/*/basepathmapping
+cloudformation:GET                  *
+cloudfront:UpdateDistribution       *
+route53:ListHostedZones             *
+route53:ChangeResourceRecordSets    hostedzone/{HostedZoneId}
+route53:GetHostedZone               *
+route53:ListResourceRecordSets      *
+iam:CreateServiceLinkedRole         arn:aws:iam::${AWS::AccountId}: role/aws-service-role/ops.apigateway.amazonaws.com/AWSServiceRoleForAPIGateway
+```
+
+NOTE: there was an [original request](https://github.com/Open-SL/serverless-permission-generator/issues/19) to separate Route53 concepts in the builder as a sub-option of the domain manager selector.
+
+NOTE: Currently providing a resource of `hostedzone/*` instead of `hostedzone/{HostedZoneId}`

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -46,6 +46,8 @@ export default function Form({ setPolicy }) {
           isS3Required: false,
           isSnsRequired: false,
           isSqsRequired: false,
+          isDomainManagerRequired: false,
+          isDomainManagerRoute53Required: false,
           isApiGWRequired: false,
           isSgRequired: false,
           isKinesisRequired: false,
@@ -359,6 +361,44 @@ export default function Form({ setPolicy }) {
                     <FormHelperText className={classes.helperText}>{errors.isSqsRequired}</FormHelperText>
                   )}
                 </Grid>
+              </Grid>
+
+              <Grid container direction="row" justify="center" alignItems="center" spacing={1}>
+                <Grid item xs={8}>
+                  <Typography variant="subtitle1" className={classes.fieldTitle}>
+                    Serverless Domain Manager
+                  </Typography>
+                </Grid>
+                <Grid item xs>
+                  <Field
+                    component={Checkbox}
+                    type="checkbox"
+                    name="isDomainManagerRequired"
+                    inputProps={{ 'aria-label': 'sqs checkbox' }}
+                  />
+                </Grid>
+
+                {values.isDomainManagerRequired && <>
+                  <Grid item xs={6}>
+                    <Typography variant="subtitle1" className={classes.fieldTitle}>
+                      Allow Route53
+                  </Typography>
+                  </Grid>
+                  <Grid item xs>
+                    <Field
+                      component={Checkbox}
+                      type="checkbox"
+                      name="isDomainManagerRoute53Required"
+                      inputProps={{ 'aria-label': 'sqs checkbox' }}
+                    />
+                  </Grid>
+
+                  <Grid item xs={12}>
+                    {errors.isDomainManagerRoute53Required && (
+                      <FormHelperText className={classes.helperText}>{errors.isDomainManagerRoute53Required}</FormHelperText>
+                    )}
+                  </Grid></>
+                }
               </Grid>
 
               <Grid container direction="row" justify="center" alignItems="center" spacing={2}>


### PR DESCRIPTION
## Added

+ Added support for the [serverless domain manager](https://www.npmjs.com/package/serverless-domain-manager)
+ Added optional support to turn on/off the Route53 requirements as a sub-option for the SDM
+ Added a docs path in such case other plugins appear - a place to store localized docs for each function

## Updated
+ Flattened the array of permissions so functions could return more than one structure
